### PR TITLE
chore:  ignore files in results when language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+results/* linguist-generated


### PR DESCRIPTION
Add `.gitattributes` to ignore files in results when language statistics.