### PR TITLE
Fix median 6700K typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ CPU                                                                            |
 Intel Core i9-12900K, 8P+8E Cores, Alder Lake, 12th gen, 2021-Q4               | 35ns, 44ns, 50ns
 Intel Core i9-9900K, 3.60GHz, 8 Cores, Coffee Lake, 9th gen, 2018-Q4           | 21ns
 Intel Core i7-1165G7, 2.80GHz, 4 Cores, Tiger Lake, 11th gen, 2020-Q3          | 27ns
-Intel Core i7-6700K, 4.00GHz, 4 Cores, Skylake, 6th gen, 2015-Q3               | 27ns
+Intel Core i7-6700K, 4.00GHz, 4 Cores, Skylake, 6th gen, 2015-Q3               | 20ns
 Intel Core i5-10310U, 4 Cores, Comet Lake, 10th gen, 2020-Q2                   | 21ns
 Intel Core i5-4590, 3.30GHz 4 Cores, Haswell, 4th gen, 2014-Q2                 | 21ns
 Apple M1 Pro, 6P+2E Cores, 2021-Q4                                             | 40ns, 53ns, 145ns


### PR DESCRIPTION
I believe this was a typo, my test result had Min=18.9ns Median=20.0ns Max=20.9ns