### PR TITLE
Update core_affinity dependency to version 0.8.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 exclude = ["/results"]
 
 [dependencies]
-core_affinity = "0.5"
+core_affinity = "0.8.3"
 quanta = "0.10"
 clap = { version = "3", features = ["derive"] }
 ndarray = "0.15"


### PR DESCRIPTION
Allows building on Windows for ARM64, since core_affinity 0.5 depends on an out-of-date version of winapi (version 0.2.28) which does not support Windows for ARM64.