### PR TITLE
Added --no-recycling option which allocates new pages for each CPU pairs to fix erroneous results on Zen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ ordered-float = "3"
 cache-padded = "1.2"
 crossbeam-utils = { version = "0.8", default-features = false }
 raw-cpuid = "10"
+memmap2 = "0.9"

--- a/README.md
+++ b/README.md
@@ -390,6 +390,90 @@ It can be used in the jupter notebook [results/results.ipynb](results/results.ip
 
 Create a GitHub issue with the generated `output.csv` file and I'll add your results.
 
+CLI Options
+-----------
+
+### Core Selection (`--cores`)
+
+Specify which cores to benchmark by ID. Supports individual IDs and inclusive ranges:
+
+```bash
+# Use specific cores
+core-to-core-latency --cores 7,11,13
+
+# Use core ranges
+core-to-core-latency --cores 0-19
+
+# Mix ranges and individual IDs
+core-to-core-latency --cores 9-44,56-63
+```
+
+By default, all available cores are used.
+
+### Multi-Address CAS (`--num_addresses`)
+
+Test CAS latency across multiple cache lines simultaneously:
+
+```bash
+# Test with 4 cache lines
+core-to-core-latency --bench 1 --num_addresses 4
+```
+
+Each address is a separate cache line. The benchmark runs each address sequentially
+per core pair and reports per-address statistics.
+
+### CSV Output (`--csv`, `--csv-output-prefix`)
+
+Enable structured CSV file output:
+
+```bash
+# Write CSV files with default prefix "report"
+core-to-core-latency --csv
+
+# Write CSV files with custom prefix
+core-to-core-latency --csv --csv-output-prefix myresults
+```
+
+When `--csv` is enabled, two files are produced per benchmark:
+
+#### `<prefix>.<bench>.per_address.csv`
+
+One row per core pair per address.
+
+| Column | Description |
+|--------|-------------|
+| `ping_core` | CPU core ID running the "ping" thread |
+| `pong_core` | CPU core ID running the "pong" thread |
+| `ping_numa` | NUMA node of ping core (placeholder: 0) |
+| `pong_numa` | NUMA node of pong core (placeholder: 0) |
+| `mem_numa` | NUMA node of memory allocation (placeholder: 0) |
+| `address` | Address index (0-based) |
+| `vaddr` | Virtual address of the cache line |
+| `mean_latency` | Mean latency in nanoseconds |
+| `median_latency` | Median latency in nanoseconds |
+| `min_latency` | Minimum latency |
+| `max_latency` | Maximum latency |
+| `cv_percent` | Coefficient of variation (%) |
+
+#### `<prefix>.<bench>.summary.csv`
+
+One row per core pair, aggregated across all addresses.
+
+| Column | Description |
+|--------|-------------|
+| `ping_core` | CPU core ID running the "ping" thread |
+| `pong_core` | CPU core ID running the "pong" thread |
+| `ping_numa` | NUMA node of ping core (placeholder: 0) |
+| `pong_numa` | NUMA node of pong core (placeholder: 0) |
+| `mem_numa` | NUMA node of memory allocation (placeholder: 0) |
+| `mean_of_means` | Mean of per-address mean latencies |
+| `mean_of_medians` | Mean of per-address median latencies |
+| `min_latency` | Minimum across addresses |
+| `max_latency` | Maximum across addresses |
+| `cv_percent` | Coefficient of variation (%) |
+
+A legacy N x N CSV matrix is also printed to stdout for backward compatibility.
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -422,6 +422,17 @@ core-to-core-latency --bench 1 --num_addresses 4
 Each address is a separate cache line. The benchmark runs each address sequentially
 per core pair and reports per-address statistics.
 
+### Using Only Fresh Memory Pages (`--no-recycling`)
+
+Allocate new unique memory for each cpu-pairs during CAS test using mmap.
+
+```bash
+# Allocate new unique memory pages for each cpu-pairs
+core-to-core-latency --bench 1 --no-recycling
+```
+
+This is necessary for properly measuring core latency on some systems like AMD EPYC and ThreadRipper.
+
 ### CSV Output (`--csv`, `--csv-output-prefix`)
 
 Enable structured CSV file output:

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -6,40 +6,174 @@ use ansi_term::Color;
 use core_affinity::CoreId;
 use quanta::Clock;
 use std::io::Write;
-use ndarray::{s, Axis};
-use ordered_float::NotNan;
 use crate::CliArgs;
 
 pub type Count = u32;
 
-pub trait Bench {
-    fn run(&self, cores: (CoreId, CoreId), clock: &Clock, num_iterations: Count, num_samples: Count) -> Vec<f64>;
-    /// Whether the bench on (i,j) is the same as the bench on (j,i)
-    fn is_symmetric(&self) -> bool { true }
+/// Statistics computed from a sample of values -- shared by all benchmarks
+pub struct Stats {
+    pub mean: f64,
+    pub median: f64,
+    pub min: f64,
+    pub max: f64,
+    pub cv_percent: f64,
 }
 
-pub fn run_bench(cores: &[CoreId], clock: &Clock, args: &CliArgs, bench: impl Bench) {
+impl Stats {
+    /// Compute statistics from a slice of f64 values.
+    /// Returns None if the slice is empty or contains only NaN values.
+    pub fn compute(values: &[f64]) -> Option<Self> {
+        let mut valid: Vec<f64> = values.iter().copied().filter(|v| !v.is_nan()).collect();
+        if valid.is_empty() {
+            return None;
+        }
+
+        let arr = ndarray::arr1(&valid);
+        let mean = arr.mean().unwrap();
+        // std(1.0) uses ddof=1 (sample std dev), which divides by n-1.
+        // When n==1, this produces NaN. Treat cv_percent as 0.0 in that case.
+        let cv_percent = if valid.len() <= 1 {
+            0.0
+        } else {
+            let stddev = arr.std(1.0);
+            if mean > 0.0 { stddev / mean * 100.0 } else { 0.0 }
+        };
+
+        let min = *valid.iter().min_by(|a, b| a.partial_cmp(b).unwrap()).unwrap();
+        let max = *valid.iter().max_by(|a, b| a.partial_cmp(b).unwrap()).unwrap();
+
+        valid.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let median = if valid.len() % 2 == 0 {
+            (valid[valid.len() / 2 - 1] + valid[valid.len() / 2]) / 2.0
+        } else {
+            valid[valid.len() / 2]
+        };
+
+        Some(Self { mean, median, min, max, cv_percent })
+    }
+}
+
+/// Helper module for CSV file creation
+pub mod csv_output {
+    use std::fs::File;
+    use std::io::BufWriter;
+
+    /// Create a CSV file with standard naming: <prefix>.<bench_name>.<suffix>.csv
+    ///
+    /// Returns None and prints error if file creation fails.
+    pub fn create_csv(prefix: &str, bench_name: &str, suffix: &str) -> Option<BufWriter<File>> {
+        let path = format!("{}.{}.{}.csv", prefix, bench_name, suffix);
+
+        match File::create(&path) {
+            Ok(file) => {
+                eprintln!("    Writing CSV: {}", path);
+                Some(BufWriter::new(file))
+            }
+            Err(e) => {
+                eprintln!("    ERROR: Failed to create {}: {}", path, e);
+                None
+            }
+        }
+    }
+}
+
+pub trait Bench {
+    fn run(&self, cores: (CoreId, CoreId), clock: &Clock, num_iterations: Count, num_samples: Count) -> Vec<Vec<f64>>;
+    /// Whether the bench on (i,j) is the same as the bench on (j,i)
+    fn is_symmetric(&self) -> bool { true }
+    /// Number of addresses this benchmark tests
+    fn num_addresses(&self) -> usize { 1 }
+    /// Get the virtual addresses of the storage for each address index.
+    /// Returns empty vec if not applicable.
+    fn address_ptrs(&self) -> Vec<usize> { vec![] }
+    /// Get the NUMA node where memory is allocated.
+    /// Returns 0 if NUMA is not applicable or not tracked.
+    fn mem_numa(&self) -> usize { 0 }
+}
+
+/// Per-address statistics for a single core pair
+struct PerAddressRow {
+    ping_core: usize,
+    pong_core: usize,
+    ping_numa: usize,      // NUMA node of ping core
+    pong_numa: usize,      // NUMA node of pong core
+    mem_numa: usize,       // NUMA node where memory is allocated
+    address: usize,
+    vaddr: usize,
+    mean: f64,
+    median: f64,
+    min: f64,
+    max: f64,
+    cv_percent: f64,
+}
+
+/// Per-pair summary (aggregated across addresses)
+struct PerPairSummary {
+    ping_core: usize,
+    pong_core: usize,
+    ping_numa: usize,      // NUMA node of ping core
+    pong_numa: usize,      // NUMA node of pong core
+    mem_numa: usize,       // NUMA node where memory is allocated
+    mean_of_means: f64,
+    mean_of_medians: f64,
+    min: f64,
+    max: f64,
+    cv_percent: f64,
+}
+
+pub fn run_bench(cores: &[CoreId], clock: &Clock, args: &CliArgs, bench: impl Bench, bench_name: &str) {
     let num_samples = args.num_samples;
     let num_iterations = args.num_iterations;
+    let num_addresses = bench.num_addresses();
+    let address_ptrs = bench.address_ptrs();
 
     let n_cores = cores.len();
     assert!(n_cores >= 2);
-    let shape = ndarray::Ix3(n_cores, n_cores, num_samples as usize);
-    let mut results = ndarray::Array::from_elem(shape, f64::NAN);
+
+    // Running stats for overall summary (streaming approach to reduce memory)
+    let mut running_sum = 0.0;
+    let mut running_count = 0u64;
+
+    // Track min/max for both mean-of-means and mean-of-medians
+    let mut min_latency_by_mean: Option<(f64, usize, usize)> = None;
+    let mut max_latency_by_mean: Option<(f64, usize, usize)> = None;
+    let mut min_latency_by_median: Option<(f64, usize, usize)> = None;
+    let mut max_latency_by_median: Option<(f64, usize, usize)> = None;
+
+    // Collect rows for CSV output. Only pre-allocate when CSV is requested.
+    let n_pairs = if bench.is_symmetric() { n_cores * (n_cores - 1) / 2 } else { n_cores * (n_cores - 1) };
+    let mut per_address_rows: Vec<PerAddressRow> = if args.csv {
+        Vec::with_capacity(n_pairs * num_addresses)
+    } else {
+        Vec::new()
+    };
+    let mut per_pair_summaries: Vec<PerPairSummary> = if args.csv {
+        Vec::with_capacity(n_pairs)
+    } else {
+        Vec::new()
+    };
+
+    // Legacy N x N matrix for stdout CSV output (mean-of-means).
+    // Only allocated when CSV output is requested.
+    let mut legacy_matrix: Vec<Vec<f64>> = if args.csv {
+        vec![vec![f64::NAN; n_cores]; n_cores]
+    } else {
+        Vec::new()
+    };
 
     // First print the column header
     eprint!("    {: >3}", "");
     for j in cores {
-        eprint!(" {: >4}{: >3}", j.id, "");
-        //        |||
-        //        ||+-- Width
-        //        |+--- Align
-        //        +---- Fill
+        eprint!(" {: >4}{: >4}", j.id, "");
     }
     eprintln!();
 
     let mcolor = Color::White.bold();
     let scolor = Color::White.dimmed();
+
+    let mut pair_means = Vec::with_capacity(num_addresses);
+    let mut pair_medians = Vec::with_capacity(num_addresses);
+    let mut all_samples = vec![0.0; num_samples as usize];
 
     // Do the benchmark
     for i in 0..n_cores {
@@ -51,71 +185,207 @@ pub fn run_bench(cores: &[CoreId], clock: &Clock, args: &CliArgs, bench: impl Be
                    continue;
                 }
             } else if i == j {
-                eprint!("{: >8}", "");
+                eprint!("{: >9}", "");
                 continue;
             }
 
             let core_j = cores[j];
             // We add 1 warmup cycle first
             let durations = bench.run((core_i, core_j), clock, num_iterations, 1+num_samples);
-            let durations = &durations[1..];
-            let mut values = results.slice_mut(s![i,j,..]);
-            for s in 0..num_samples as usize {
-                values[s] = durations[s]
+
+            pair_means.clear();
+            pair_medians.clear();
+            all_samples.fill(0.0);
+
+            for addr_idx in 0..num_addresses {
+                // Skip the first (warmup) sample
+                let samples: &[f64] = &durations[addr_idx][1..];
+
+                // Update running totals for overall summary
+                for &val in samples {
+                    running_sum += val;
+                    running_count += 1;
+                }
+
+                // Accumulate for per-pair display (average across addresses)
+                for (s, &val) in samples.iter().enumerate() {
+                    all_samples[s] += val / num_addresses as f64;
+                }
+
+                // Compute per-address statistics
+                if let Some(stats) = Stats::compute(samples) {
+                    pair_means.push(stats.mean);
+                    pair_medians.push(stats.median);
+
+                    if args.csv {
+                        let vaddr = if addr_idx < address_ptrs.len() {
+                            address_ptrs[addr_idx]
+                        } else {
+                            0
+                        };
+                        per_address_rows.push(PerAddressRow {
+                            ping_core: cores[i].id,
+                            pong_core: cores[j].id,
+                            ping_numa: 0,
+                            pong_numa: 0,
+                            mem_numa: bench.mem_numa(),
+                            address: addr_idx,
+                            vaddr,
+                            mean: stats.mean,
+                            median: stats.median,
+                            min: stats.min,
+                            max: stats.max,
+                            cv_percent: stats.cv_percent,
+                        });
+                    }
+                }
             }
 
-            let mean = format!("{: >4.0}", values.mean().unwrap());
-            // We apply the central limit theorem to estimate the standard deviation
-            let stddev = format!("±{: <2.0}", values.std(1.0).min(99.0) / (num_samples as f64).sqrt());
+            // Compute per-pair summary (aggregated across addresses)
+            if !pair_means.is_empty() && !pair_medians.is_empty() {
+                let mean_of_means = pair_means.iter().sum::<f64>() / pair_means.len() as f64;
+                let mean_of_medians = pair_medians.iter().sum::<f64>() / pair_medians.len() as f64;
+
+                // Track min/max by mean-of-means
+                match &min_latency_by_mean {
+                    None => min_latency_by_mean = Some((mean_of_means, i, j)),
+                    Some((min_val, _, _)) if mean_of_means < *min_val => min_latency_by_mean = Some((mean_of_means, i, j)),
+                    _ => {}
+                }
+                match &max_latency_by_mean {
+                    None => max_latency_by_mean = Some((mean_of_means, i, j)),
+                    Some((max_val, _, _)) if mean_of_means > *max_val => max_latency_by_mean = Some((mean_of_means, i, j)),
+                    _ => {}
+                }
+
+                // Track min/max by mean-of-medians
+                match &min_latency_by_median {
+                    None => min_latency_by_median = Some((mean_of_medians, i, j)),
+                    Some((min_val, _, _)) if mean_of_medians < *min_val => min_latency_by_median = Some((mean_of_medians, i, j)),
+                    _ => {}
+                }
+                match &max_latency_by_median {
+                    None => max_latency_by_median = Some((mean_of_medians, i, j)),
+                    Some((max_val, _, _)) if mean_of_medians > *max_val => max_latency_by_median = Some((mean_of_medians, i, j)),
+                    _ => {}
+                }
+
+                if args.csv {
+                    legacy_matrix[i][j] = mean_of_means;
+                    if bench.is_symmetric() {
+                        legacy_matrix[j][i] = mean_of_means;
+                    }
+                }
+
+                if args.csv {
+                    // For the summary rows, compute stats from means
+                    if let Some(stats) = Stats::compute(&pair_means) {
+                        per_pair_summaries.push(PerPairSummary {
+                            ping_core: cores[i].id,
+                            pong_core: cores[j].id,
+                            ping_numa: 0,
+                            pong_numa: 0,
+                            mem_numa: bench.mem_numa(),
+                            mean_of_means,
+                            mean_of_medians,
+                            min: stats.min,
+                            max: stats.max,
+                            cv_percent: stats.cv_percent,
+                        });
+                    }
+                }
+            }
+
+            // Display matrix entry
+            let all_samples_arr = ndarray::arr1(&all_samples);
+            let mean = format!("{: >4.0}", all_samples_arr.mean().unwrap());
+            let stddev = format!("+-{: <2.0}", all_samples_arr.std(1.0).min(99.0) / (num_samples as f64).sqrt());
             eprint!(" {}{}", mcolor.paint(mean), scolor.paint(stddev));
-            let _ = std::io::stdout().lock().flush();
+            let _ = std::io::stderr().lock().flush();
         }
         eprintln!();
     }
 
     eprintln!();
 
-    // Print min/max latency
-    {
-        let mean = results.mean_axis(Axis(2)).unwrap();
-        let stddev = results.std_axis(Axis(2), 1.0) / (num_samples as f64).sqrt();
-
-        let ((min_i, min_j), _) = mean.indexed_iter()
-            .filter_map(|(i, v)| NotNan::new(*v).ok().map(|v| (i, v)))
-            .min_by_key(|(_, v)| *v)
-            .unwrap();
-        let min_mean = format!("{:.1}", mean[(min_i, min_j)]);
-        let min_stddev = format!("±{:.1}", stddev[(min_i, min_j)]);
-        let (min_core_id_i, min_core_id_j) = (cores[min_i].id, cores[min_j].id);
-
-        let ((max_i, max_j), _) = mean.indexed_iter()
-            .filter_map(|(i, v)| NotNan::new(*v).ok().map(|v| (i, v)))
-            .max_by_key(|(_, v)| *v)
-            .unwrap();
-        let max_mean = format!("{:.1}", mean[(max_i, max_j)]);
-        let max_stddev = format!("±{:.1}", stddev[(max_i, max_j)]);
-        let (max_core_id_i, max_core_id_j) = (cores[max_i].id, cores[max_j].id);
-
-        eprintln!("    Min  latency: {}ns {} cores: ({},{})", mcolor.paint(min_mean), scolor.paint(min_stddev), min_core_id_i, min_core_id_j);
-        eprintln!("    Max  latency: {}ns {} cores: ({},{})", mcolor.paint(max_mean), scolor.paint(max_stddev), max_core_id_i, max_core_id_j);
+    // Print min/max latency (using median-based, which is more robust)
+    eprintln!("    {} (robust to outliers):", scolor.paint("Median-based stats"));
+    if let Some((min_val, min_i, min_j)) = min_latency_by_median {
+        eprintln!("      Min  latency: {}ns cores: ({},{})",
+                 mcolor.paint(format!("{:.1}", min_val)), cores[min_i].id, cores[min_j].id);
+    }
+    if let Some((max_val, max_i, max_j)) = max_latency_by_median {
+        eprintln!("      Max  latency: {}ns cores: ({},{})",
+                 mcolor.paint(format!("{:.1}", max_val)), cores[max_i].id, cores[max_j].id);
     }
 
-    // Print mean latency
-    {
-        let values = results.iter().copied().filter(|v| !v.is_nan()).collect::<Vec<_>>();
-        let values = ndarray::arr1(&values);
-        let mean = format!("{:.1}", values.mean().unwrap());
-        // no stddev, it's hard to put a value that is meaningful without a lengthy explanation
-        eprintln!("    Mean latency: {}ns", mcolor.paint(mean));
+    eprintln!("    {} (sensitive to outliers):", scolor.paint("Mean-based stats"));
+    if let Some((min_val, min_i, min_j)) = min_latency_by_mean {
+        eprintln!("      Min  latency: {}ns cores: ({},{})",
+                 mcolor.paint(format!("{:.1}", min_val)), cores[min_i].id, cores[min_j].id);
+    }
+    if let Some((max_val, max_i, max_j)) = max_latency_by_mean {
+        eprintln!("      Max  latency: {}ns cores: ({},{})",
+                 mcolor.paint(format!("{:.1}", max_val)), cores[max_i].id, cores[max_j].id);
     }
 
+    // Print overall mean latency (computed from running totals)
+    if running_count > 0 {
+        let overall_mean = running_sum / running_count as f64;
+        eprintln!("    Overall mean latency: {}ns", mcolor.paint(format!("{:.1}", overall_mean)));
+    }
+
+    // Write CSV files if requested
     if args.csv {
-        let results = results.mean_axis(Axis(2)).unwrap();
-        for row in results.rows() {
-            let row = row.iter()
-                .map(|v| if v.is_nan() { "".to_string() } else { v.to_string() })
-                .collect::<Vec<_>>().join(",");
-            println!("{}", row);
+        write_csv_files(&args.csv_output_prefix, bench_name, &per_address_rows, &per_pair_summaries);
+
+        // Print labeled N x N matrix CSV to stdout (enhanced format with
+        // core ID header row and row labels, values at 1 decimal place).
+        // Header row: empty cell, then core IDs
+        print!(",");
+        for core in cores {
+            print!("{}", core.id);
+            if core.id != cores.last().unwrap().id {
+                print!(",");
+            }
+        }
+        println!();
+
+        // Data rows: core ID, then latency values
+        for i in 0..n_cores {
+            print!("{}", cores[i].id);
+            for j in 0..n_cores {
+                print!(",");
+                let val = legacy_matrix[i][j];
+                if !val.is_nan() {
+                    print!("{:.1}", val);
+                }
+            }
+            println!();
+        }
+    }
+}
+
+fn write_csv_files(prefix: &str, bench_name: &str, per_address_rows: &[PerAddressRow], per_pair_summaries: &[PerPairSummary]) {
+    // Write per-address CSV
+    if let Some(mut writer) = csv_output::create_csv(prefix, bench_name, "per_address") {
+        writeln!(writer, "ping_core,pong_core,ping_numa,pong_numa,mem_numa,address,vaddr,mean_latency,median_latency,min_latency,max_latency,cv_percent").unwrap();
+        for row in per_address_rows {
+            writeln!(writer, "{},{},{},{},{},{},0x{:x},{:.2},{:.2},{:.2},{:.2},{:.2}",
+                    row.ping_core, row.pong_core, row.ping_numa, row.pong_numa, row.mem_numa,
+                    row.address, row.vaddr,
+                    row.mean, row.median, row.min, row.max, row.cv_percent).unwrap();
+        }
+    }
+
+    // Write combined summary CSV (includes both mean-of-means and mean-of-medians)
+    if let Some(mut writer) = csv_output::create_csv(prefix, bench_name, "summary") {
+        writeln!(writer, "ping_core,pong_core,ping_numa,pong_numa,mem_numa,mean_of_means,mean_of_medians,min_latency,max_latency,cv_percent").unwrap();
+        for row in per_pair_summaries {
+            writeln!(writer, "{},{},{},{},{},{:.2},{:.2},{:.2},{:.2},{:.2}",
+                    row.ping_core, row.pong_core, row.ping_numa, row.pong_numa, row.mem_numa,
+                    row.mean_of_means, row.mean_of_medians,
+                    row.min, row.max, row.cv_percent).unwrap();
         }
     }
 }

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -78,7 +78,7 @@ pub mod csv_output {
 }
 
 pub trait Bench {
-    fn run(&self, cores: (CoreId, CoreId), clock: &Clock, num_iterations: Count, num_samples: Count) -> Vec<Vec<f64>>;
+    fn run(&self, args: &CliArgs, cores: (CoreId, CoreId), clock: &Clock, num_iterations: Count, num_samples: Count) -> Vec<Vec<f64>>;
     /// Whether the bench on (i,j) is the same as the bench on (j,i)
     fn is_symmetric(&self) -> bool { true }
     /// Number of addresses this benchmark tests
@@ -191,7 +191,7 @@ pub fn run_bench(cores: &[CoreId], clock: &Clock, args: &CliArgs, bench: impl Be
 
             let core_j = cores[j];
             // We add 1 warmup cycle first
-            let durations = bench.run((core_i, core_j), clock, num_iterations, 1+num_samples);
+            let durations = bench.run(args, (core_i, core_j), clock, num_iterations, 1+num_samples);
 
             pair_means.clear();
             pair_medians.clear();

--- a/src/bench/cas.rs
+++ b/src/bench/cas.rs
@@ -7,64 +7,96 @@ use super::Count;
 const PING: bool = false;
 const PONG: bool = true;
 
+const CACHELINE_SIZE: usize = 64;
+
+#[repr(C, align(64))]
+struct CachelinePadded {
+    flag: AtomicBool,
+    _padding: [u8; CACHELINE_SIZE - std::mem::size_of::<AtomicBool>()],
+}
+
 pub struct Bench {
     barrier: Barrier,
-    flag: AtomicBool,
+    flags: Vec<CachelinePadded>,
 }
 
 impl Bench {
-    pub fn new() -> Self {
+    pub fn new(num_addresses: usize) -> Self {
+        let flags: Vec<CachelinePadded> = (0..num_addresses)
+            .map(|_| CachelinePadded {
+                flag: AtomicBool::new(PING),
+                _padding: [0; CACHELINE_SIZE - std::mem::size_of::<AtomicBool>()],
+            })
+            .collect();
         Self {
             barrier: Barrier::new(2),
-            flag: AtomicBool::new(PING),
+            flags,
         }
     }
 }
 
 impl super::Bench for Bench {
-    // The two threads modify the same cacheline.
-    // This is useful to benchmark spinlock performance.
     fn run(
         &self,
         (ping_core, pong_core): (CoreId, CoreId),
         clock: &Clock,
         num_round_trips: Count,
         num_samples: Count,
-    ) -> Vec<f64> {
+    ) -> Vec<Vec<f64>> {
         let state = self;
+        let num_addresses = state.flags.len();
 
-        crossbeam_utils::thread::scope(|s| {
-            let pong = s.spawn(move |_| {
-                core_affinity::set_for_current(pong_core);
+        let mut all_results = Vec::with_capacity(num_addresses);
 
-                state.barrier.wait();
-                for _ in 0..(num_round_trips*num_samples) {
-                    while state.flag.compare_exchange(PING, PONG, Ordering::Relaxed, Ordering::Relaxed).is_err() {}
-                }
-            });
+        for addr_idx in 0..num_addresses {
+            let results = crossbeam_utils::thread::scope(|s| {
+                let pong = s.spawn(move |_| {
+                    core_affinity::set_for_current(pong_core);
 
-            let ping = s.spawn(move |_| {
-                core_affinity::set_for_current(ping_core);
-
-                let mut results = Vec::with_capacity(num_samples as usize);
-
-                state.barrier.wait();
-
-                for _ in 0..num_samples {
-                    let start = clock.raw();
-                    for _ in 0..num_round_trips {
-                        while state.flag.compare_exchange(PONG, PING, Ordering::Relaxed, Ordering::Relaxed).is_err() {}
+                    state.barrier.wait();
+                    for _ in 0..(num_round_trips*num_samples) {
+                        while state.flags[addr_idx].flag.compare_exchange(PING, PONG, Ordering::Relaxed, Ordering::Relaxed).is_err() {}
                     }
-                    let end = clock.raw();
-                    let duration = clock.delta(start, end).as_nanos();
-                    results.push(duration as f64 / num_round_trips as f64 / 2.0);
-                }
+                });
 
-                results
-            });
+                let ping = s.spawn(move |_| {
+                    core_affinity::set_for_current(ping_core);
 
-            pong.join().unwrap();
-            ping.join().unwrap()
-        }).unwrap()
+                    let mut results = Vec::with_capacity(num_samples as usize);
+
+                    state.barrier.wait();
+
+                    for _ in 0..num_samples {
+                        let start = clock.raw();
+                        for _ in 0..num_round_trips {
+                            while state.flags[addr_idx].flag.compare_exchange(PONG, PING, Ordering::Relaxed, Ordering::Relaxed).is_err() {}
+                        }
+                        let end = clock.raw();
+                        let duration = clock.delta(start, end).as_nanos();
+                        results.push(duration as f64 / num_round_trips as f64 / 2.0);
+                    }
+
+                    results
+                });
+
+                pong.join().unwrap();
+                ping.join().unwrap()
+            }).unwrap();
+
+            all_results.push(results);
+
+            // Reset the flag for the next iteration
+            state.flags[addr_idx].flag.store(PING, Ordering::Relaxed);
+        }
+
+        all_results
+    }
+
+    fn num_addresses(&self) -> usize {
+        self.flags.len()
+    }
+
+    fn address_ptrs(&self) -> Vec<usize> {
+        self.flags.iter().map(|f| f as *const _ as usize).collect()
     }
 }

--- a/src/bench/cas.rs
+++ b/src/bench/cas.rs
@@ -3,6 +3,8 @@ use std::sync::Barrier;
 use std::sync::atomic::{AtomicBool, Ordering};
 use quanta::Clock;
 use super::Count;
+use memmap2::MmapMut;
+use crate::CliArgs;
 
 const PING: bool = false;
 const PONG: bool = true;
@@ -36,8 +38,10 @@ impl Bench {
 }
 
 impl super::Bench for Bench {
+
     fn run(
         &self,
+        args: &CliArgs,
         (ping_core, pong_core): (CoreId, CoreId),
         clock: &Clock,
         num_round_trips: Count,
@@ -47,6 +51,28 @@ impl super::Bench for Bench {
         let num_addresses = state.flags.len();
 
         let mut all_results = Vec::with_capacity(num_addresses);
+        let mut mmap_flags = Vec::<CachelinePadded>::new();
+
+        let flags = &{
+            if args.no_recycling {
+                core_affinity::set_for_current(ping_core);
+
+                let size = CACHELINE_SIZE * num_addresses;
+
+                let mmap = MmapMut::map_anon(size).expect("map_anon failed");
+
+                mmap_flags = unsafe {
+                    Vec::<CachelinePadded>::from_raw_parts(mmap.as_ptr() as *mut CachelinePadded, num_addresses, num_addresses)
+                };
+                let _ = std::mem::ManuallyDrop::new(mmap);
+                for n in 0..mmap_flags.len() {
+                    mmap_flags[n as usize].flag = AtomicBool::new(PING);
+                }
+                &mmap_flags
+            } else {
+                &state.flags
+            }
+        };
 
         for addr_idx in 0..num_addresses {
             let results = crossbeam_utils::thread::scope(|s| {
@@ -54,8 +80,9 @@ impl super::Bench for Bench {
                     core_affinity::set_for_current(pong_core);
 
                     state.barrier.wait();
+                    let flag = &flags[addr_idx].flag;
                     for _ in 0..(num_round_trips*num_samples) {
-                        while state.flags[addr_idx].flag.compare_exchange(PING, PONG, Ordering::Relaxed, Ordering::Relaxed).is_err() {}
+                        while flag.compare_exchange(PING, PONG, Ordering::Relaxed, Ordering::Relaxed).is_err() {}
                     }
                 });
 
@@ -66,10 +93,11 @@ impl super::Bench for Bench {
 
                     state.barrier.wait();
 
+                    let flag = &flags[addr_idx].flag;
                     for _ in 0..num_samples {
                         let start = clock.raw();
                         for _ in 0..num_round_trips {
-                            while state.flags[addr_idx].flag.compare_exchange(PONG, PING, Ordering::Relaxed, Ordering::Relaxed).is_err() {}
+                            while flag.compare_exchange(PONG, PING, Ordering::Relaxed, Ordering::Relaxed).is_err() {}
                         }
                         let end = clock.raw();
                         let duration = clock.delta(start, end).as_nanos();
@@ -87,6 +115,11 @@ impl super::Bench for Bench {
 
             // Reset the flag for the next iteration
             state.flags[addr_idx].flag.store(PING, Ordering::Relaxed);
+        }
+
+
+        if args.no_recycling {
+            let _ = std::mem::ManuallyDrop::new(mmap_flags);
         }
 
         all_results

--- a/src/bench/msg_passing.rs
+++ b/src/bench/msg_passing.rs
@@ -13,7 +13,10 @@ pub struct Bench {
 }
 
 impl Bench {
-    pub fn new(num_iterations: u32) -> Self {
+    pub fn new(num_iterations: u32, num_addresses: usize) -> Self {
+        if num_addresses != 1 {
+            eprintln!("    WARN: num_addresses={} ignored for msg_passing (only supports 1)", num_addresses);
+        }
         let clocks = (0..num_iterations as usize).map(|_| Default::default()).collect();
         Self {
             barrier: Barrier::new(2),
@@ -32,7 +35,7 @@ impl super::Bench for Bench {
         clock: &Clock,
         num_iterations: Count,
         num_samples: Count,
-    ) -> Vec<f64> {
+    ) -> Vec<Vec<f64>> {
         let clock_read_overhead_sum = utils::clock_read_overhead_sum(clock, num_iterations);
 
         // A shared time reference
@@ -91,7 +94,7 @@ impl super::Bench for Bench {
             });
 
             sender.join().unwrap();
-            receiver.join().unwrap()
+            vec![receiver.join().unwrap()]
         }).unwrap()
     }
 }

--- a/src/bench/msg_passing.rs
+++ b/src/bench/msg_passing.rs
@@ -3,6 +3,7 @@ use core_affinity::CoreId;
 use std::sync::Barrier;
 use std::sync::atomic::{Ordering, AtomicU64};
 use quanta::Clock;
+use crate::CliArgs;
 
 use super::Count;
 use crate::utils;
@@ -31,6 +32,7 @@ impl super::Bench for Bench {
 
     fn run(
         &self,
+        _args: &CliArgs,
         (recv_core, send_core): (CoreId, CoreId),
         clock: &Clock,
         num_iterations: Count,

--- a/src/bench/read_write.rs
+++ b/src/bench/read_write.rs
@@ -13,7 +13,10 @@ pub struct Bench {
 }
 
 impl Bench {
-    pub fn new() -> Self {
+    pub fn new(num_addresses: usize) -> Self {
+        if num_addresses != 1 {
+            eprintln!("    WARN: num_addresses={} ignored for read_write (only supports 1)", num_addresses);
+        }
         Self {
             barrier: CachePadded::new(Barrier::new(2)),
             owned_by_ping: Default::default(),
@@ -31,7 +34,7 @@ impl super::Bench for Bench {
         clock: &Clock,
         num_round_trips: Count,
         num_samples: Count,
-    ) -> Vec<f64> {
+    ) -> Vec<Vec<f64>> {
         let state = self;
 
         crossbeam_utils::thread::scope(|s| {
@@ -71,7 +74,7 @@ impl super::Bench for Bench {
             });
 
             pong.join().unwrap();
-            ping.join().unwrap()
+            vec![ping.join().unwrap()]
         }).unwrap()
     }
 }

--- a/src/bench/read_write.rs
+++ b/src/bench/read_write.rs
@@ -3,6 +3,7 @@ use core_affinity::CoreId;
 use std::sync::Barrier;
 use std::sync::atomic::{Ordering, AtomicBool};
 use quanta::Clock;
+use crate::CliArgs;
 
 use super::Count;
 
@@ -30,6 +31,7 @@ impl super::Bench for Bench {
     // Thread 2 writes to cache line 2 and read cache line 1
     fn run(
         &self,
+        _args: &CliArgs,
         (ping_core, pong_core): (CoreId, CoreId),
         clock: &Clock,
         num_round_trips: Count,

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,11 @@ pub struct CliArgs {
     /// By default all cores are used.
     #[clap(short, long, require_delimiter=true, value_delimiter=',', value_parser)]
     cores: Vec<String>,
+
+    /// Enable allocating fresh anonymous pages for each core pairs. {n}
+    /// Those are "leaked" to insure they do not get reused until the benchmark ends.
+    #[clap(long, value_parser)]
+    no_recycling: bool,
 }
 
 fn parse_cores(specs: &[String], all_cores: &[CoreId]) -> Vec<CoreId> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,16 @@ mod bench;
 mod utils;
 
 use bench::Count;
+use std::collections::HashSet;
 use std::sync::Arc;
 use clap::Parser;
+use core_affinity::CoreId;
 use quanta::Clock;
 use crate::bench::run_bench;
 
 const DEFAULT_NUM_SAMPLES: Count = 300;
 const DEFAULT_NUM_ITERATIONS_PER_SAMPLE: Count = 1000;
+const DEFAULT_NUM_ADDRESSES: usize = 1;
 
 #[derive(Clone)]
 #[derive(clap::Parser)]
@@ -21,40 +24,105 @@ pub struct CliArgs {
     #[clap(default_value_t = DEFAULT_NUM_SAMPLES, value_parser)]
     num_samples: Count,
 
-    /// Outputs the mean latencies in CSV format on stdout
+    /// The number of addresses to test (each address is a separate cacheline)
+    #[clap(long, default_value_t = DEFAULT_NUM_ADDRESSES, value_parser)]
+    pub num_addresses: usize,
+
+    /// Output CSV files with latency data. When enabled, writes two files per benchmark: {n}
+    ///   <prefix>.<bench>.per_address.csv - Per-address latency for each core pair {n}
+    ///   <prefix>.<bench>.summary.csv - Summary with mean-of-means and mean-of-medians {n}
+    /// Note: Mean-based statistics can be skewed by occasional high-latency samples {n}
+    /// caused by interrupts or scheduling. Median-based statistics are more robust.
     #[clap(long, value_parser)]
     csv: bool,
+
+    /// Prefix for CSV output files (default: "report")
+    #[clap(long, default_value = "report", value_parser)]
+    pub csv_output_prefix: String,
 
     /// Select which benchmark to run, in a comma delimited list, e.g., '1,3' {n}
     /// 1: CAS latency on a single shared cache line. {n}
     /// 2: Single-writer single-reader latency on two shared cache lines. {n}
-    /// 3: One writer and one reader on many cache line, using the clock. {n}
+    /// 3: One writer and one reader on many cache line, using the clock.
     #[clap(short, long, default_value="1", require_delimiter=true, value_delimiter=',', value_parser)]
     bench: Vec<usize>,
 
-    /// Specify the cores by id that should be used, comma delimited. By default all cores are used.
+    /// Specify the cores by id. Supports individual IDs and inclusive ranges. {n}
+    /// Examples: --cores 7,11,13  or  --cores 9-44,56-63  or  --cores 0-19 {n}
+    /// By default all cores are used.
     #[clap(short, long, require_delimiter=true, value_delimiter=',', value_parser)]
-    cores: Vec<usize>,
+    cores: Vec<String>,
+}
+
+fn parse_cores(specs: &[String], all_cores: &[CoreId]) -> Vec<CoreId> {
+    if specs.is_empty() {
+        return all_cores.to_vec();
+    }
+
+    let valid_ids: HashSet<usize> = all_cores.iter().map(|c| c.id).collect();
+    let mut selected_ids: Vec<usize> = Vec::new();
+
+    for spec in specs {
+        let spec = spec.trim();
+        if spec.contains('-') {
+            let parts: Vec<&str> = spec.splitn(2, '-').collect();
+            let start: usize = parts[0].parse()
+                .unwrap_or_else(|_| panic!("Invalid range start in '{}': '{}'", spec, parts[0]));
+            let end: usize = parts[1].parse()
+                .unwrap_or_else(|_| panic!("Invalid range end in '{}': '{}'", spec, parts[1]));
+            if start > end {
+                panic!("Invalid range '{}': start ({}) > end ({})", spec, start, end);
+            }
+            for id in start..=end {
+                selected_ids.push(id);
+            }
+        } else {
+            let id: usize = spec.parse()
+                .unwrap_or_else(|_| panic!("Invalid core id: '{}'", spec));
+            selected_ids.push(id);
+        }
+    }
+
+    let mut seen = HashSet::new();
+    for &id in &selected_ids {
+        if !seen.insert(id) {
+            panic!("Duplicate core id: {}", id);
+        }
+    }
+
+    for &id in &selected_ids {
+        if !valid_ids.contains(&id) {
+            let mut available: Vec<usize> = valid_ids.iter().copied().collect();
+            available.sort();
+            panic!("Core {} not found. Available: {:?}", id, available);
+        }
+    }
+
+    if selected_ids.len() < 2 {
+        panic!("--cores must specify at least 2 cores, got {}", selected_ids.len());
+    }
+
+    selected_ids.iter()
+        .map(|&id| *all_cores.iter().find(|c| c.id == id).unwrap())
+        .collect()
 }
 
 fn main() {
     let args = CliArgs::parse();
 
-    let cores = core_affinity::get_core_ids().expect("get_core_ids() failed");
-
-    let cores = if !args.cores.is_empty() {
-        args.cores.iter().copied()
-            .map(|cid| *cores.iter().find(|c| c.id == cid)
-                .unwrap_or_else(||panic!("Core {} not found. Available: {:?}", cid, &cores)))
-            .collect()
-    } else {
-        cores
-    };
+    let all_cores = core_affinity::get_core_ids().expect("get_core_ids() failed");
+    let cores = parse_cores(&args.cores, &all_cores);
 
     utils::show_cpuid_info();
     eprintln!("Num cores: {}", cores.len());
     eprintln!("Num iterations per samples: {}", args.num_iterations);
     eprintln!("Num samples: {}", args.num_samples);
+
+    if args.num_addresses == 0 {
+        eprintln!("ERROR: --num-addresses must be at least 1");
+        std::process::exit(1);
+    }
+
     #[cfg(target_os = "macos")]
     eprintln!("{}", ansi_term::Color::Red.bold().paint("WARN macOS may ignore thread-CPU affinity (we can't select a CPU to run on). Results may be inaccurate"));
 
@@ -66,20 +134,20 @@ fn main() {
                 eprintln!();
                 eprintln!("1) CAS latency on a single shared cache line");
                 eprintln!();
-                run_bench(&cores, &clock, &args, bench::cas::Bench::new());
+                run_bench(&cores, &clock, &args, bench::cas::Bench::new(args.num_addresses), "cas");
             }
             2 => {
                 eprintln!();
                 eprintln!("2) Single-writer single-reader latency on two shared cache lines");
                 eprintln!();
-                run_bench(&cores, &clock, &args, bench::read_write::Bench::new());
+                run_bench(&cores, &clock, &args, bench::read_write::Bench::new(args.num_addresses), "read_write");
             }
             3 => {
                 utils::assert_rdtsc_usable(&clock);
                 eprintln!();
                 eprintln!("3) Message passing. One writer and one reader on many cache line");
                 eprintln!();
-                run_bench(&cores, &clock, &args, bench::msg_passing::Bench::new(args.num_iterations));
+                run_bench(&cores, &clock, &args, bench::msg_passing::Bench::new(args.num_iterations, args.num_addresses), "msg_passing");
             }
             _ => panic!("--bench should be 1, 2 or 3"),
         }


### PR DESCRIPTION
This fixes the issue of cache lines residing on a 3rd core during the benchmark's entire execution on AMD Zen systems, particularly on EPYC and Threadripper.

It allocates fresh memory pages using mmap on *Nix or VirtualAlloc on Windows and does not free them to prevent the OS returning them again later.

This PR builds on b3nj1's multi-address branch.

## With --no-recycling:
<img width="1046" height="1098" alt="image" src="https://github.com/user-attachments/assets/00706e16-08ab-4268-ba76-4d6f3be5201d" />

## Without:
<img width="910" height="952" alt="image" src="https://github.com/user-attachments/assets/fff062a8-4600-4395-bcb5-b8fdbc175611" />
